### PR TITLE
Attempting to fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: 1.0.{build}
 configuration: Debug
+image: Visual Studio 2017
 environment:
   COVERALLS_REPO_TOKEN: SET_IN_USER_INTERFACE
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build:
   verbosity: minimal
 test_script:
 - ps: >-
-    .\testrunner\OpenCover.4.6.166\tools\OpenCover.Console.exe -register:user -target:nunit3-console.exe "-targetargs:--result=myresults.xml RTSP.Tests\bin\$env:CONFIGURATION\RTSP.Tests.dll" -filter:"+[*]Rtsp* -[*.Tests]*" -output:opencoverCoverage.xml
+    .\testrunner\OpenCover.4.6.166\tools\OpenCover.Console.exe -register:user -target:nunit3-console.exe "-targetargs:--result=myresults.xml RTSP.Core.Tests\bin\$env:CONFIGURATION\netcoreapp2.0\RTSP.Tests.dll" -filter:"+[*]Rtsp* -[*.Tests]*" -output:opencoverCoverage.xml
     
     $coveralls = (Resolve-Path "./testrunner/coveralls.net.*/tools/csmacnz.coveralls.exe").ToString()
     


### PR DESCRIPTION
You'll still need to set up coveralls.io and add its repo token to appveyor as a COVERALLS_REPO_TOKEN env variable. There might still be issues after that, but I at least got a green light.